### PR TITLE
Move vscode to devDependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,8 +11,10 @@
 		"update-vscode": "yarn vscode-install",
 		"postinstall": "yarn vscode-install"
 	},
+	"devDependencies": {
+		"vscode": "^1.1.22"
+	},	
 	"dependencies": {
-		"vscode": "^1.1.22",
 		"vscode-languageclient": "^5.1.1"
 	}
 }


### PR DESCRIPTION
This moves the vscode module to devDependencies, as its not distributed with the published extension.